### PR TITLE
Add API route to log current ISO time

### DIFF
--- a/app/api/log-time/route.ts
+++ b/app/api/log-time/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  const now = new Date().toISOString();
+  console.log('Current ISO Time:', now);
+  return new Response(`Logged time: ${now}`);
+}
+cat: app/api/log-time/route.ts: No such file or directory


### PR DESCRIPTION
Created a new API route at `app/api/log-time/route.ts` that logs the current ISO time to the console and responds with the logged time.