### PR TITLE
Add function to count 'r' characters in a word (Python)

### DIFF
--- a/output.txt
+++ b/output.txt
@@ -1,0 +1,27 @@
+# Code Execution Result
+
+## Description
+Python function to count the number of 'r' characters in a word. Includes example usage with the word 'rural'.
+
+## Language & Version
+python - Python 3.9.23
+
+## Generated Code
+```python
+def count_rs(word):
+    """Returns the number of 'r' characters in the given word. Case sensitive."""
+    return word.count('r')
+
+# Example usage
+word = 'rural'
+output = count_rs(word)
+output
+```
+
+## Execution Output
+```
+
+```
+
+## Generated At
+2025-09-12T19:11:53.933Z


### PR DESCRIPTION
This PR adds a Python function that counts the number of 'r' characters in a word. Includes example usage with the word 'rural'. See output.txt for details.